### PR TITLE
Handle external plugins repo in Nix tooling

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -15,6 +15,14 @@
     ...
   }: let
     inherit (nixpkgs) lib;
+
+    # Optional override to provide a local/plugins source without requiring
+    # an additional flake input. When unset, plugins are not vendored.
+    pluginsSrc =
+      let envPath = builtins.getEnv "DRACONIS_PLUGINS_SRC"; in
+      if envPath == ""
+      then null
+      else builtins.path {path = envPath; name = "draconisplusplus-plugins";};
   in
     {homeModules.default = import ./nix/module.nix {inherit self;};}
     // utils.lib.eachDefaultSystem (
@@ -61,7 +69,7 @@
             wayland
           ]));
 
-        draconisPkgs = import ./nix {inherit nixpkgs self system lib;};
+        draconisPkgs = import ./nix {inherit nixpkgs self system lib pluginsSrc;};
       in {
         packages = draconisPkgs;
         checks = draconisPkgs;

--- a/meson.build
+++ b/meson.build
@@ -168,9 +168,19 @@ project_public_includes = include_directories('include', is_system: true)
 third_party_includes = include_directories('third_party', is_system: true)
 
 # For static plugins, add the cloned plugins repo to include path
-# This allows #include "plugins/..." to work with the cloned repo structure
-plugins_includes = include_directories('plugins', is_system: true)
-includes_dep = declare_dependency(include_directories: [project_public_includes, third_party_includes, plugins_includes])
+# This allows #include "plugins/..." to work with the cloned repo structure.
+plugins_dir = meson.project_source_root() / 'plugins'
+plugins_includes = []
+
+if fs.is_dir(plugins_dir)
+  plugins_includes = [include_directories('plugins', is_system: true)]
+else
+  message('Plugins directory not found; static plugins will be unavailable unless provided externally.')
+endif
+
+includes_dep = declare_dependency(
+  include_directories: [project_public_includes, third_party_includes] + plugins_includes,
+)
 
 # ================ #
 #   Dependencies   #

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,6 +3,7 @@
   self,
   system,
   lib,
+  pluginsSrc ? null,
   # devkitNix ? null,
   ...
 }: let
@@ -11,11 +12,11 @@
     # overlays = lib.optional (devkitNix != null) devkitNix.overlays.default;
   };
 
-  dracPackages = import ./package.nix {inherit pkgs self lib;};
+  dracPackages = import ./package.nix {inherit pkgs self lib pluginsSrc;};
 
   muslPackages =
     if pkgs.stdenv.isLinux
-    then import ./musl.nix {inherit pkgs nixpkgs self lib;}
+    then import ./musl.nix {inherit pkgs nixpkgs self lib pluginsSrc;}
     else {};
 in
   dracPackages

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -5,7 +5,7 @@
   ...
 }:
 with lib; let
-  cfg = config.programs.draconisplusplus;
+  cfg = config.programs.draconisplusplus or {};
 
   tomlFormat = pkgs.formats.toml {};
 
@@ -243,7 +243,14 @@ with lib; let
       #endif
     '';
 
-  draconisWithOverrides = cfg.package.overrideAttrs (oldAttrs: {
+  packageWithPlugins =
+    if cfg.pluginsSrc == null
+    then cfg.package
+    else if lib.hasAttr "override" cfg.package
+    then cfg.package.override {pluginsSrc = cfg.pluginsSrc;}
+    else cfg.package;
+
+  draconisWithOverrides = packageWithPlugins.overrideAttrs (oldAttrs: {
     postPatch =
       (oldAttrs.postPatch or "")
       + lib.optionalString (cfg.configFormat == "hpp") ''
@@ -271,6 +278,12 @@ in {
       type = types.package;
       default = defaultPackage;
       description = "The base draconis++ package.";
+    };
+
+    pluginsSrc = mkOption {
+      type = types.nullOr types.path;
+      default = null;
+      description = "Path to the draconis++ plugins repository for static plugin builds.";
     };
 
     configFormat = mkOption {
@@ -504,4 +517,5 @@ in {
       }
     ];
   };
+
 }


### PR DESCRIPTION
## Summary
- allow providing a plugins source via `DRACONIS_PLUGINS_SRC` and pass it through Nix packages and the Home Manager module
- link an optional plugins checkout into derivations so static plugin builds can use the split repository
- make Meson tolerate absent plugins directories when none are provided
- make the Nix packages overridable so `pluginsSrc` can be injected, and guard the module against packages without an `override` attribute
- revert the `myconfig.programs.draconisplusplus` alias to keep options under the standard namespace

## Testing
- not run (environment lacks required tooling)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694473d9b2a883289046dce3adb5a498)