### PR TITLE
Fix Nix derivation build failure

### DIFF
--- a/nix/boost-ut.nix
+++ b/nix/boost-ut.nix
@@ -8,7 +8,7 @@ stdenv.mkDerivation rec {
     owner = "boost-ext";
     repo = "ut";
     rev = "v${version}";
-    sha256 = "1cd9bssapl5pclp8wiv5hl92c74d4sbx7lprqcq9g0856y3z26z5";
+    hash = "sha256-VCTrs0CMr4pUrJ2zEsO8s7j16zOkyDNhBc5zw0rAAZI=";
   };
 
   sourceRoot = "ut-${version}";


### PR DESCRIPTION
Update the hash for boost-ut v2.3.1 to match the actual GitHub tarball. The previous hash was incorrect, causing derivation build failures.